### PR TITLE
added check against underflow in GMX

### DIFF
--- a/src/services/debit/GmxService.sol
+++ b/src/services/debit/GmxService.sol
@@ -97,7 +97,7 @@ contract GmxService is Whitelisted, AuctionRateModel, DebitService {
             totalCollateral;
         // Subtracting the virtual deposit we get the weth part: this is the weth the user is entitled to
         // Due to integer arithmetic, we may get underflow if we do not make checks
-        uint256 toTransfer = totalWithdraw >= virtualDeposit[tokenID] + finalBalance
+        uint256 toTransfer = totalWithdraw >= virtualDeposit[tokenID] + (finalBalance - initialBalance)
             ? totalWithdraw - virtualDeposit[tokenID]
             : 0;
         // delete virtual deposits

--- a/src/services/debit/GmxService.sol
+++ b/src/services/debit/GmxService.sol
@@ -87,22 +87,26 @@ contract GmxService is Whitelisted, AuctionRateModel, DebitService {
             address(this)
         );
 
-        uint256 wethBalance = weth.balanceOf(address(this));
+        uint256 initialBalance = weth.balanceOf(address(this));
         router.handleRewards(false, false, false, false, false, true, false);
         // register rewards
-        uint256 newRewards = totalRewards + (weth.balanceOf(address(this)) - wethBalance);
+        uint256 finalBalance = weth.balanceOf(address(this));
+        uint256 newRewards = totalRewards + (finalBalance - initialBalance);
         // calculate share of rewards to give to the user
         uint256 totalWithdraw = ((newRewards + totalVirtualDeposits) * agreement.collaterals[0].amount) /
             totalCollateral;
         // Subtracting the virtual deposit we get the weth part: this is the weth the user is entitled to
-        uint256 toTransfer = totalWithdraw - virtualDeposit[tokenID];
+        // Due to integer arithmetic, we may get underflow if we do not make checks
+        uint256 toTransfer = totalWithdraw >= virtualDeposit[tokenID] + finalBalance
+            ? totalWithdraw - virtualDeposit[tokenID]
+            : 0;
         // delete virtual deposits
         totalVirtualDeposits -= virtualDeposit[tokenID];
         delete virtualDeposit[tokenID];
         // update totalRewards and totalCollateral
         totalRewards = newRewards - toTransfer;
         totalCollateral -= agreement.collaterals[0].amount;
-        // Transfer weth
+        // Transfer weth: since toTransfer <= totalWithdraw
         weth.safeTransfer(msg.sender, toTransfer);
     }
 

--- a/test/services/GmxService.test.sol
+++ b/test/services/GmxService.test.sol
@@ -11,6 +11,19 @@ import { GeneralMath } from "../helpers/GeneralMath.sol";
 import { OrderHelper } from "../helpers/OrderHelper.sol";
 import { BaseIntegrationServiceTest } from "./BaseIntegrationServiceTest.sol";
 
+contract MockRouter {
+    uint256 public amount;
+    IERC20 internal constant weth = IERC20(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
+
+    constructor(uint256 _amount) {
+        amount = _amount;
+    }
+
+    function handleRewards(bool, bool, bool, bool, bool, bool, bool) external {
+        weth.transfer(msg.sender, amount);
+    }
+}
+
 contract GmxServiceTest is BaseIntegrationServiceTest {
     GmxService internal immutable service;
 
@@ -19,21 +32,24 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
     address internal constant glpRewardTracker = 0xd2D1162512F927a7e282Ef43a362659E4F2a728F;
     IERC20 internal constant weth = IERC20(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
     IERC20 internal constant usdc = IERC20(0xaf88d065e77c8cC2239327C5EDb3A432268e5831); // USDC Native
-    address internal constant whale = 0x8b8149Dd385955DC1cE77a4bE7700CCD6a212e65;
+    address internal constant whale = 0x0dF5dfd95966753f01cb80E76dc20EA958238C46;
     // USDC whale cannot be GMX itself, or it will break the contract!
     address internal constant usdcWhale = 0xE68Ee8A12c611fd043fB05d65E1548dC1383f2b9;
-    uint256 internal constant amount = 1 * 1e18; // 1 WETH
+    uint256 internal constant amount = 1 * 1e20; // 100 WETH
     uint256 internal constant usdcAmount = 1e10; // 10k USDC
 
     string internal constant rpcUrl = "ARBITRUM_RPC_URL";
     uint256 internal constant blockNumber = 119065280;
 
+    MockRouter internal mockRouter;
+
     constructor() BaseIntegrationServiceTest(rpcUrl, blockNumber) {
         vm.deal(admin, 1 ether);
         vm.deal(whale, 1 ether);
 
+        mockRouter = new MockRouter(1e16);
         vm.prank(admin);
-        service = new GmxService(address(manager), gmxRouter, gmxRouterV2, 30 * 86400);
+        service = new GmxService(address(manager), address(mockRouter), gmxRouterV2, 30 * 86400);
     }
 
     function _equalityWithTolerance(uint256 amount1, uint256 amount2, uint256 tolerance) internal {
@@ -45,8 +61,10 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         weth.approve(address(service), type(uint256).max);
         usdc.approve(address(service), type(uint256).max);
 
-        vm.prank(whale);
+        vm.startPrank(whale);
         weth.transfer(admin, 1);
+        weth.transfer(address(mockRouter), 1e18);
+        vm.stopPrank();
         vm.prank(usdcWhale);
         usdc.transfer(admin, 1);
         vm.startPrank(admin);
@@ -56,10 +74,12 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         manager.setCap(address(service), address(weth), GeneralMath.RESOLUTION, type(uint256).max);
         manager.create(address(usdc));
         manager.setCap(address(service), address(usdc), GeneralMath.RESOLUTION, type(uint256).max);
+        service.setRiskParams(address(weth), 0, 0, 86400);
+        service.setRiskParams(address(usdc), 0, 0, 86400);
         vm.stopPrank();
 
         vm.startPrank(whale);
-        weth.transfer(address(this), 1e18);
+        weth.transfer(address(this), 1e20);
         IVault vault = IVault(manager.vaults(address(weth)));
         weth.approve(address(vault), type(uint256).max);
         vault.deposit(amount, whale);
@@ -73,7 +93,7 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         vm.stopPrank();
     }
 
-    function testGmxIntegration(uint256 loanAmount, uint256 margin) private {
+    function _openGmxEth(uint256 loanAmount, uint256 margin) internal {
         address[] memory tokens = new address[](1);
         tokens[0] = address(weth);
 
@@ -81,7 +101,7 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         loans[0] = loanAmount % 1e18;
 
         uint256[] memory margins = new uint256[](1);
-        margins[0] = (margin % 9e17) + 1e17;
+        margins[0] = margin;
 
         IService.ItemType[] memory itemTypes = new IService.ItemType[](1);
         itemTypes[0] = IService.ItemType.ERC20;
@@ -92,8 +112,6 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         uint256[] memory collateralAmounts = new uint256[](1);
         collateralAmounts[0] = 0;
 
-        uint256 initial = weth.balanceOf(address(this)) - margins[0];
-
         IService.Order memory order = OrderHelper.createAdvancedOrder(
             tokens,
             loans,
@@ -106,17 +124,9 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         );
 
         service.open(order);
-
-        (IService.Loan[] memory loan, IService.Collateral[] memory collaterals, uint256 createdAt, ) = service
-            .getAgreement(0);
-
-        IService.Agreement memory agreement = IService.Agreement(loan, collaterals, createdAt, IService.Status.OPEN);
-
-        service.close(0, abi.encode(uint256(1)));
-        assertEq(weth.balanceOf(address(this)), initial + service.quote(agreement)[0] - loans[0]);
     }
 
-    function testGmxIntegrationUsdc(uint256 loanAmount, uint256 margin) public {
+    function _openGmxUsdc(uint256 loanAmount, uint256 margin) internal {
         address[] memory tokens = new address[](1);
         tokens[0] = address(usdc);
 
@@ -124,7 +134,7 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         loans[0] = loanAmount % usdcAmount;
 
         uint256[] memory margins = new uint256[](1);
-        margins[0] = (margin % 9e7) + 1e8;
+        margins[0] = margin;
 
         IService.ItemType[] memory itemTypes = new IService.ItemType[](1);
         itemTypes[0] = IService.ItemType.ERC20;
@@ -135,8 +145,6 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         uint256[] memory collateralAmounts = new uint256[](1);
         collateralAmounts[0] = ((loans[0] + margins[0]) * 99 * 1e12) / 100;
 
-        uint256 initial = usdc.balanceOf(address(this)) - margins[0];
-
         IService.Order memory order = OrderHelper.createAdvancedOrder(
             tokens,
             loans,
@@ -149,6 +157,28 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         );
 
         service.open(order);
+    }
+
+    function testGmxIntegration(uint256 loanAmount, uint256 margin) public {
+        margin = (margin % 9e17) + 1e17;
+        uint256 initial = weth.balanceOf(address(this)) - margin;
+        _openGmxEth(loanAmount, margin);
+        (IService.Loan[] memory loan, IService.Collateral[] memory collaterals, uint256 createdAt, ) = service
+            .getAgreement(0);
+
+        IService.Agreement memory agreement = IService.Agreement(loan, collaterals, createdAt, IService.Status.OPEN);
+
+        service.close(0, abi.encode(uint256(1)));
+        assertEq(
+            weth.balanceOf(address(this)),
+            initial + mockRouter.amount() + service.quote(agreement)[0] - loan[0].amount
+        );
+    }
+
+    function testGmxIntegrationUsdc(uint256 loanAmount, uint256 margin) public {
+        margin = (margin % 9e7) + 1e8;
+        uint256 initial = usdc.balanceOf(address(this)) - margin;
+        _openGmxUsdc(loanAmount, margin);
 
         (IService.Loan[] memory loan, IService.Collateral[] memory collaterals, uint256 createdAt, ) = service
             .getAgreement(0);
@@ -156,6 +186,28 @@ contract GmxServiceTest is BaseIntegrationServiceTest {
         IService.Agreement memory agreement = IService.Agreement(loan, collaterals, createdAt, IService.Status.OPEN);
 
         service.close(0, abi.encode(uint256(1)));
-        _equalityWithTolerance(usdc.balanceOf(address(this)), initial + service.quote(agreement)[0] - loans[0], 1);
+        _equalityWithTolerance(
+            usdc.balanceOf(address(this)),
+            initial + service.quote(agreement)[0] - loan[0].amount,
+            1
+        );
+    }
+
+    // setting to private since it becomes too heavy
+    function testHeavyTesting(uint256 loanAmount, uint256 margin, uint256 seed) private {
+        margin = (((margin % 1e17) + (seed % 987654321)) % 1e17) + 1e16;
+        _openGmxEth(loanAmount, margin);
+        margin = (((margin % 1e17) + (seed % 123456789)) % 1e17) + 1e16;
+        _openGmxEth(loanAmount, margin);
+        margin = (((margin % 1e17) + (seed % 345678901)) % 1e17) + 1e16;
+        _openGmxEth(loanAmount, margin);
+        service.close(1, abi.encode(uint256(1)));
+        margin = (((margin % 1e17) + (seed % 514614341)) % 1e17) + 1e16;
+        _openGmxEth(loanAmount, margin);
+        margin = (((margin % 1e17) + (seed % 514614341)) % 1e17) + 1e16;
+        service.close(0, abi.encode(uint256(1)));
+        _openGmxEth(loanAmount, margin);
+        service.close(4, abi.encode(uint256(1)));
+        service.close(2, abi.encode(uint256(1)));
     }
 }


### PR DESCRIPTION
The basic identity is (R+V+(R+V)c_j/C)c_i/(C+c_j) = (R+V)c_i/C, which is however false in integer (floored) arithmetic. In particular, in some cases it can be shown that the first quantity can be _less_ than the second one, leading to a potential underflow when subtracting the virtualDeposits. A check on the underflow prevents this.

No sweeping is needed, since when only one position is open, totalCollaterals and collateral is the same, and the last position wipes the entire weth balance.